### PR TITLE
add assumes to metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build/
 *.charm
 *.vscode
+/.idea/
 
 *.coverage
 venv

--- a/k8s-charm/metadata.yaml
+++ b/k8s-charm/metadata.yaml
@@ -2,6 +2,9 @@
 # See LICENSE file for licensing details.
 
 name: juju-dashboard-k8s
+assumes:
+- k8s-api
+- juju >= 3.0
 description: |
   Kubernetes Charm for the Juju Dashboard
 summary: |

--- a/machine-charm/metadata.yaml
+++ b/machine-charm/metadata.yaml
@@ -1,6 +1,8 @@
 # Copyright 2021 Canonical
 # See LICENSE file for licensing details.
 name: juju-dashboard
+assumes:
+- juju >= 3.0
 display-name: |
   Charm for Juju Dashboard
 description: |


### PR DESCRIPTION
In Juju 2.9, the dashboard is automatically deployed with the controller. The dashboard charm needs a relation to the controller charm, which is only supported in Juju 3.0+. Hence, this charm only makes sense in Juju 3.0+.

Add `assumes: juju >= 3.0` to metadata.yaml so that this charm can only deploy on Juju 3.0 or later. We also add `assumes: k8s-api` to the k8s version, so that it won't deploy on machine clouds.

## QA steps

- Ensure that neither charm can be deployed on 2.9.
- Ensure that the k8s charm can't be deployed on LXD.
- Ensure that both charms can be deployed on the correct cloud for Juju 3.0.