### PR TITLE
add "/commands" endpoint reverse proxy

### DIFF
--- a/k8s-charm/src/nginx.conf.j2
+++ b/k8s-charm/src/nginx.conf.j2
@@ -31,4 +31,12 @@ server {
         proxy_set_header Connection $connection_upgrade;
         proxy_set_header Host $host;
     }
+
+    location ~ /commands$ {
+        proxy_pass {{controller_ws_api}};
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $host;
+    }
 }


### PR DESCRIPTION
# Done

- Fix the inaccessible `ws://HOST/model/commands`

 