### PR TITLE
WD-3990 - Update dashboard repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,17 +72,17 @@ microk8s config | juju add-k8s --client micro
 juju bootstrap micro
 ```
 
-## jaas-dashboard
+## juju-dashboard
 
 ### Using the latest release
 
-There is no need to `git clone` the repository, in the section "[Building the Kubernetes Charm](#building-the-kubernetes-charm)" we will set the `<image-id>` to `canonicalwebteam/jaas-dashboard:latest`
+There is no need to `git clone` the repository, in the section "[Building the Kubernetes Charm](#building-the-kubernetes-charm)" we will set the `<image-id>` to `canonicalwebteam/juju-dashboard:latest`
 
 ### Building from source
 
-[Source](https://github.com/canonical-web-and-design/jaas-dashboard#readme)
+[Source](https://github.com/canonical/juju-dashboard#readme)
 
-1. Checkout `git@github.com:canonical-web-and-design/jaas-dashboard.git`
+1. Checkout `git@github.com:canonical/juju-dashboard.git`
 2. Build the container with `DOCKER_BUILDKIT=1 docker build -t juju-dashboard .`
 3. Take note of the image id. You can get it with `docker image inspect juju-dashboard | grep "Id"`
 4. Add the docker image that you just build to microk8s' build in docker repo, as it cannot talk to the docker registry on the host machine: `docker image save juju-dashboard | microk8s ctr image import -`
@@ -100,7 +100,7 @@ charmcraft pack
 juju switch controller
 # image id must include: "sha256:..."
 # using latest OCI release
-juju deploy --resource dashboard-image=canonicalwebteam/jaas-dashboard:latest ./juju-dashboard*.charm dashboard
+juju deploy --resource dashboard-image=canonicalwebteam/juju-dashboard:latest ./juju-dashboard*.charm dashboard
 # alternatively, using a custom OCI image
 # juju deploy --resource dashboard-image=<image id> ./juju-dashboard*.charm dashboard
 juju relate controller dashboard
@@ -150,8 +150,8 @@ charmcraft release juju-dashboard --channel=... --revision=...
 ### Update the Docker image
 
 ```sh
-git clone git@github.com:canonical-web-and-design/jaas-dashboard.git
-cd jaas-dashboard
+git clone git@github.com:canonical/juju-dashboard.git
+cd juju-dashboard
 DOCKER_BUILDKIT=1 docker build -t juju-dashboard .
 ```
 

--- a/k8s-charm/README.md
+++ b/k8s-charm/README.md
@@ -25,7 +25,7 @@ It requires the "juju-dashboard" interface on the Juju controller charm.
 
 ## OCI Images
 
-This charm uses the JAAS team's build of the dashboard: canonicalwebteam/jaas-dashboard:latest
+This charm uses the JAAS team's build of the dashboard: canonicalwebteam/juju-dashboard:latest
 
 ## Contributing
 

--- a/k8s-charm/metadata.yaml
+++ b/k8s-charm/metadata.yaml
@@ -3,8 +3,8 @@
 
 name: juju-dashboard-k8s
 assumes:
-- k8s-api
-- juju >= 3.0
+  - k8s-api
+  - juju >= 3.0
 description: |
   Kubernetes Charm for the Juju Dashboard
 summary: |
@@ -18,8 +18,8 @@ resources:
   dashboard-image:
     type: oci-image
     description: |
-      Canonical build of the dashboard (canonicalwebteam/jaas-dashboard:latest)
-    
+      Canonical build of the dashboard (canonicalwebteam/juju-dashboard:latest)
+
 provides:
   dashboard:
     interface: http
@@ -27,5 +27,3 @@ provides:
 requires:
   controller:
     interface: juju-dashboard
-    
-

--- a/machine-charm/src/charm.py
+++ b/machine-charm/src/charm.py
@@ -68,7 +68,7 @@ class JujuDashboardCharm(CharmBase):
             self._configure(data['controller_url'], data['identity_provider_url'], data['is_juju'])
 
     def _configure(self, controller_url, identity_provider_url, is_juju):
-        """Configure and restart our nginx and jaas-dashboard services."""
+        """Configure and restart our nginx and juju-dashboard services."""
 
         # Load up nginx templates and poke at system.
         env = Environment(loader=FileSystemLoader(os.getcwd()))

--- a/scripts/update-machine-charm-dashboard.sh
+++ b/scripts/update-machine-charm-dashboard.sh
@@ -8,7 +8,7 @@ rm -rf $dist_path/*
 echo "Downloading the latest release..."
 rm -f *.tar.bz2
 
-wget -qO- https://api.github.com/repos/canonical/jaas-dashboard/releases/latest \
+wget -qO- https://api.github.com/repos/canonical/juju-dashboard/releases/latest \
 | grep tar.bz2 \
 | cut -d : -f 2,3 \
 | tr -d \" \


### PR DESCRIPTION
## Done
- Renamed references to the dashboard repo to use the new name.
- Replaced references to "JAAS" with "Juju" where appropriate.
- Corrected image name (it was already set to "juju-dashboard" but was referred to as "jaas-dashboard" in some places.)

https://warthogs.atlassian.net/browse/WD-3990