### PR TITLE
WD-7717 - Add analytics config

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,43 @@
+name: CI
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  test-machine:
+    name: Test machine charm
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./machine-charm
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install requirements
+        run: |
+          python3 -m venv venv
+          source venv/bin/activate
+          pip install -r requirements-dev.txt
+      - name: Run tests
+        run: ./run_tests
+  test-k8s:
+    name: Test K8s charm
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./k8s-charm
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install requirements
+        run: |
+          python3 -m venv venv
+          source venv/bin/activate
+          pip install -r requirements-dev.txt
+      - name: Run tests
+        run: ./run_tests

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ juju deploy ubuntu
 
 # Switch to the controller model and setup the dashboard
 juju switch controller
+# If apt fails to install packages when deploying the dashboard you may need to run the following:
+# sudo iptables -P FORWARD ACCEPT
 juju deploy ./juju-dashboard*.charm dashboard
 juju relate controller dashboard
 juju dashboard
@@ -141,7 +143,7 @@ You must tell your browser to trust the controller's cert in order to get a work
 charmcraft login
 cd ./machine-charm
 charmcraft pack
-charmcraft upload juju-dashboard_[...].charm
+charmcraft upload juju-dashboard*.charm
 charmcraft release juju-dashboard --channel=... --revision=...
 ```
 

--- a/k8s-charm/config.yaml
+++ b/k8s-charm/config.yaml
@@ -18,3 +18,7 @@ options:
     default: 8080
     description: The port to serve the dashboard on.
     type: int
+  analytics-enabled:
+    default: true
+    description: Whether Google Analytics and Sentry error tracking is enabled. This data is used to improve Juju Dashboard.
+    type: boolean

--- a/k8s-charm/lib/charms/juju_dashboard/v0/juju_dashboard.py
+++ b/k8s-charm/lib/charms/juju_dashboard/v0/juju_dashboard.py
@@ -10,7 +10,6 @@ temporary) quirk with the way that the Juju 3.0 beta was returning networking da
 
 """
 import re
-from subprocess import check_output
 from typing import Mapping
 
 from ops.charm import CharmBase

--- a/k8s-charm/src/config.js.j2
+++ b/k8s-charm/src/config.js.j2
@@ -11,4 +11,6 @@ var jujuDashboardConfig = {
   // only be used for superficial updates like logos. Use feature detection
   // for other environment features.
   isJuju: {{is_juju | bool | tojson}},
+  // If true, then Google Analytics and Sentry data will be sent.
+  analyticsEnabled: {{analytics_enabled | bool | tojson}},
 };

--- a/k8s-charm/tests/test_charm.py
+++ b/k8s-charm/tests/test_charm.py
@@ -5,6 +5,7 @@
 
 import unittest
 
+from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
 
 from charm import JujuDashboardKubernetesCharm
@@ -18,21 +19,72 @@ class TestCharm(unittest.TestCase):
         self.harness.set_can_connect('dashboard', True)
         self.container = self.harness.model.unit.get_container('dashboard')
         self.container.make_dir('/srv')
-
-    def test_initial_hooks(self):
-        print("test")
-
-    def test_on_controller_relation_changed(self):
-        rel_id = self.harness.add_relation("controller", "controller")
-        self.harness.add_relation_unit(rel_id, "controller/0")
-        self.harness.update_relation_data(rel_id, "controller", {
+        self.container.make_dir('/etc/nginx/sites-available/', make_parents=True)
+        self.rel_id = self.harness.add_relation("controller", "controller")
+        self.harness.add_relation_unit(self.rel_id, "controller/0")
+        self.harness.update_relation_data(self.rel_id, "controller", {
             "controller-url": "wss://10.10.10.1:107070",
-            "is-juju": True,
+            "is-juju": "True",
             "identity-provider-url": ""
         })
 
-        nginx_config = self.container.pull('/srv/nginx.config').read()
+    def test_on_controller_relation_changed(self):
+        self.harness.update_relation_data(self.rel_id, "controller", {
+            "is-juju": "False",
+        })
+        with self.container.pull('/etc/nginx/sites-available/default') as f:
+            nginx_config = f.read()
         self.assertTrue("https://10.10.10.1:107070" in nginx_config)
+        with self.container.pull('/srv/config.js') as f:
+            config = f.read()
+        self.assertTrue("isJuju: false" in config)
 
-        config = self.container.pull('/srv/config.js').read()
-        self.assertTrue("isJuju: true" in config)
+    def test_relation_departed(self):
+        self.harness.model.unit.status = ActiveStatus()
+        self.harness.remove_relation(self.rel_id)
+        self.assertEqual(
+            self.harness.model.unit.status,
+            BlockedStatus("Missing controller integration")
+        )
+
+    def test_config_changed(self):
+        with self.container.pull('/srv/config.js') as f:
+            config = f.read()
+        self.assertTrue("analyticsEnabled: true" in config)
+        self.harness.update_config({"analytics-enabled": False})
+        with self.container.pull('/srv/config.js') as f:
+            config = f.read()
+        self.assertTrue("analyticsEnabled: false" in config)
+
+    def test_config_changed_no_relation(self):
+        self.harness.remove_relation(self.rel_id)
+        self.harness.model.unit.status = ActiveStatus()
+        self.harness.update_config({"analytics-enabled": False})
+        self.assertEqual(
+            self.harness.model.unit.status,
+            BlockedStatus("Missing controller integration")
+        )
+
+    def test_update_status(self):
+        self.harness.disable_hooks()
+        self.harness.update_config({"analytics-enabled": False})
+        self.harness.enable_hooks()
+        with self.container.pull('/srv/config.js') as f:
+            config = f.read()
+        self.assertTrue("analyticsEnabled: true" in config)
+        self.harness.charm.on.update_status.emit()
+        with self.container.pull('/srv/config.js') as f:
+            config = f.read()
+        self.assertTrue("analyticsEnabled: false" in config)
+
+    def test_upgrade_charm(self):
+        self.harness.disable_hooks()
+        self.harness.update_config({"analytics-enabled": False})
+        self.harness.enable_hooks()
+        with self.container.pull('/srv/config.js') as f:
+            config = f.read()
+        self.assertTrue("analyticsEnabled: true" in config)
+        self.harness.charm.on.upgrade_charm.emit()
+        with self.container.pull('/srv/config.js') as f:
+            config = f.read()
+        self.assertTrue("analyticsEnabled: false" in config)

--- a/machine-charm/config.yaml
+++ b/machine-charm/config.yaml
@@ -21,3 +21,7 @@ options:
   dns-name:
     description: DNS of the Juju dashboard.
     type: string
+  analytics-enabled:
+    default: true
+    description: Whether Google Analytics and Sentry error tracking is enabled. This data is used to improve Juju Dashboard.
+    type: boolean

--- a/machine-charm/src/config.js.template
+++ b/machine-charm/src/config.js.template
@@ -11,4 +11,6 @@ var jujuDashboardConfig = {
   // only be used for superficial updates like logos. Use feature detection
   // for other environment features.
   isJuju: {{is_juju | bool | tojson}},
+  // If true, then Google Analytics and Sentry data will be sent.
+  analyticsEnabled: {{analytics_enabled | bool | tojson}},
 };

--- a/machine-charm/tests/test_charm.py
+++ b/machine-charm/tests/test_charm.py
@@ -27,8 +27,6 @@ class TestDashboardRelation(unittest.TestCase):
         self.harness = Harness(charm.JujuDashboardCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin_with_initial_hooks()
-        # TODO we shouldn't have to be the leader. (We shouldn't be setting app data.)
-        self.harness.set_leader(True)
 
         self.harness.framework.model._backend.network_get = \
             lambda endpoint_name, relation_id: FAKE_ENDPOINT
@@ -44,7 +42,7 @@ class TestDashboardRelation(unittest.TestCase):
         self.harness.update_relation_data(self.rel_id, "juju-controller", {
             "controller-url": "api/some/controller/url",  # TODO: get real data
             "identity-provider-url": "api/some/provider/url",
-            "is-juju": True
+            "is-juju": "True"
         })
 
         self.assertEqual(self.harness.model.unit.status, ActiveStatus())
@@ -55,21 +53,70 @@ class TestDashboardRelation(unittest.TestCase):
         self.harness.update_relation_data(self.rel_id, "juju-controller", {
             "controller-url": "",
             "identity-provider-url": "api/some/provider/url",
-            "is-juju": True
+            "is-juju": "True"
         })
 
         self.assertEqual(self.harness.model.unit.status, BlockedStatus("Missing controller URL"))
 
+    def test_relation_departed(self):
+        self.harness.model.unit.status = ActiveStatus()
+        self.harness.remove_relation(self.rel_id)
+        self.assertEqual(
+            self.harness.model.unit.status,
+            BlockedStatus("Missing controller integration")
+        )
+
+    @mock.patch("charm.Environment")
+    @mock.patch('charm.hookenv')
+    @mock.patch('charm.os.system')
+    def test_config_changed(self, mock_system, mock_hookenv, mock_env):
+        self.assertFalse(mock_hookenv.open_port.called)
+        self.harness.update_config({"dns-name": "dashboard.test"})
+        self.assertTrue(mock_hookenv.open_port.called)
+
+    @mock.patch("charm.Environment")
+    @mock.patch('charm.hookenv')
+    @mock.patch('charm.os.system')
+    def test_config_changed_no_relation(self, mock_system, mock_hookenv, mock_env):
+        self.harness.remove_relation(self.rel_id)
+        self.harness.model.unit.status = ActiveStatus()
+        self.harness.update_config({"is-juju": True})
+        self.assertEqual(
+            self.harness.model.unit.status,
+            BlockedStatus("Missing controller integration")
+        )
+
+    @mock.patch("charm.Environment")
+    @mock.patch('charm.hookenv')
+    @mock.patch('charm.os.system')
+    def test_update_status(self, mock_system, mock_hookenv, mock_env):
+        self.harness.disable_hooks()
+        self.harness.update_config({"dns-name": "dashboard.test"})
+        self.harness.enable_hooks()
+        self.assertFalse(mock_hookenv.open_port.called)
+        self.harness.charm.on.update_status.emit()
+        self.assertTrue(mock_hookenv.open_port.called)
+
+    @mock.patch("charm.Environment")
+    @mock.patch('charm.hookenv')
+    @mock.patch('charm.os.system')
+    def test_upgrade_charm(self, mock_system, mock_hookenv, mock_env):
+        self.harness.disable_hooks()
+        self.harness.update_config({"dns-name": "dashboard.test"})
+        self.harness.enable_hooks()
+        self.assertFalse(mock_hookenv.open_port.called)
+        self.harness.charm.on.upgrade_charm.emit()
+        self.assertTrue(mock_hookenv.open_port.called)
+
     @mock.patch("charm.Environment")
     @mock.patch('charm.os.system')
     def test_could_not_start_nginx(self, mock_system, mock_env):
-        # We
         mock_system.return_value = -1
 
         self.harness.update_relation_data(self.rel_id, "juju-controller", {
             "controller-url": "api/some/controller/url",  # TODO: get real data
             "identity-provider-url": "api/some/provider/url",
-            "is-juju": True
+            "is-juju": "True"
         })
 
         self.assertEqual(


### PR DESCRIPTION
## Done

Update charms to add a config option for disabling analytics.

## QA
- Build and deploy the machine or k8s charm (there are instructions in the [readme](https://github.com/canonical/juju-dashboard-charm/) - if you have any trouble ask me as I have some notes about how I got these working).
- Open `[the dashboard url and ip]/config.js`. It should have `analyticsEnabled: true`.
- Open the dashboard, go to the controller model, then click on the dashboard app and finally click on the config button on the side.
- Change the analytics option to false and save.
- Open config.js again and this time it should have `analyticsEnabled: false`.
- Repeat these steps with the other type of charm.

## Details

https://warthogs.atlassian.net/browse/WD-7717