### PR TITLE
before 0.13.0 release changes

### DIFF
--- a/k8s-charm/lib/charms/juju_dashboard/v0/juju_dashboard.py
+++ b/k8s-charm/lib/charms/juju_dashboard/v0/juju_dashboard.py
@@ -78,17 +78,9 @@ class JujuDashData(Mapping):
 
         """
         # Juju controller provides is-juju, while JAAS provides is_juju.
-        is_juju = (
-            data.get("is_juju", True)
-            if data.get("is-juju") is None
-            else data.get("is-juju")
-        )
+        is_juju = data.get("is_juju") or data.get("is-juju", True)
         # Juju controller provides controller-url, while JAAS provides controller_url.
-        controller_url = (
-            data.get("controller_url", "")
-            if data.get("controller-url") is None
-            else data.get("controller-url")
-        )
+        controller_url = data.get("controller_url") or data.get("controller-url", "")
         # FIXME: Quick hack to fix a k8s bug in the controller charm.
         controller_url = (
             controller_url.replace("[", "").replace(":0]", "").replace("]", "")

--- a/k8s-charm/lib/charms/juju_dashboard/v0/juju_dashboard.py
+++ b/k8s-charm/lib/charms/juju_dashboard/v0/juju_dashboard.py
@@ -77,8 +77,19 @@ class JujuDashData(Mapping):
                 juju-controller application.
 
         """
+        # Juju controller provides is-juju, while JAAS provides is_juju.
+        is_juju = (
+            data.get("is_juju", True)
+            if data.get("is-juju") is None
+            else data.get("is-juju")
+        )
+        # Juju controller provides controller-url, while JAAS provides controller_url.
+        controller_url = (
+            data.get("controller_url", "")
+            if data.get("controller-url") is None
+            else data.get("controller-url")
+        )
         # FIXME: Quick hack to fix a k8s bug in the controller charm.
-        controller_url = data.get("controller-url")
         controller_url = (
             controller_url.replace("[", "").replace(":0]", "").replace("]", "")
         )
@@ -86,7 +97,7 @@ class JujuDashData(Mapping):
         self._data = {
             "controller_url": re.sub(r"\/api$", "", controller_url),
             "identity_provider_url": data.get("identity-provider-url", ""),
-            "is_juju": data.get("is-juju", True),
+            "is_juju": is_juju,
         }
 
     def __contains__(self, key):

--- a/k8s-charm/lib/charms/juju_dashboard/v0/juju_dashboard.py
+++ b/k8s-charm/lib/charms/juju_dashboard/v0/juju_dashboard.py
@@ -77,11 +77,8 @@ class JujuDashData(Mapping):
                 juju-controller application.
 
         """
-        # Juju controller provides is-juju, while JAAS provides is_juju.
-        is_juju = data.get("is-juju", True)
         # FIXME: Quick hack to fix a k8s bug in the controller charm.
-        # Juju controller provides controller-url, while JAAS provides controller_url.
-        controller_url = data.get("controller_url") or data.get("controller-url", "")
+        controller_url = data.get("controller-url", "")
         controller_url = (
             controller_url.replace("[", "").replace(":0]", "").replace("]", "")
         )
@@ -89,7 +86,7 @@ class JujuDashData(Mapping):
         self._data = {
             "controller_url": re.sub(r"\/api$", "", controller_url),
             "identity_provider_url": data.get("identity-provider-url", ""),
-            "is_juju": is_juju,
+            "is_juju": data.get("is-juju", True),
         }
 
     def __contains__(self, key):

--- a/k8s-charm/lib/charms/juju_dashboard/v0/juju_dashboard.py
+++ b/k8s-charm/lib/charms/juju_dashboard/v0/juju_dashboard.py
@@ -78,7 +78,11 @@ class JujuDashData(Mapping):
 
         """
         # Juju controller provides is-juju, while JAAS provides is_juju.
-        is_juju = data.get("is_juju") or data.get("is-juju", True)
+        is_juju = (
+            data.get("is_juju", True)
+            if data.get("is-juju") is None
+            else data.get("is-juju")
+        )
         # Juju controller provides controller-url, while JAAS provides controller_url.
         controller_url = data.get("controller_url") or data.get("controller-url", "")
         # FIXME: Quick hack to fix a k8s bug in the controller charm.

--- a/k8s-charm/lib/charms/juju_dashboard/v0/juju_dashboard.py
+++ b/k8s-charm/lib/charms/juju_dashboard/v0/juju_dashboard.py
@@ -78,11 +78,7 @@ class JujuDashData(Mapping):
 
         """
         # Juju controller provides is-juju, while JAAS provides is_juju.
-        is_juju = (
-            data.get("is_juju", True)
-            if data.get("is-juju") is None
-            else data.get("is-juju")
-        )
+        is_juju = data.get("is-juju", True)
         # FIXME: Quick hack to fix a k8s bug in the controller charm.
         # Juju controller provides controller-url, while JAAS provides controller_url.
         controller_url = data.get("controller_url") or data.get("controller-url", "")

--- a/k8s-charm/lib/charms/juju_dashboard/v0/juju_dashboard.py
+++ b/k8s-charm/lib/charms/juju_dashboard/v0/juju_dashboard.py
@@ -83,9 +83,9 @@ class JujuDashData(Mapping):
             if data.get("is-juju") is None
             else data.get("is-juju")
         )
+        # FIXME: Quick hack to fix a k8s bug in the controller charm.
         # Juju controller provides controller-url, while JAAS provides controller_url.
         controller_url = data.get("controller_url") or data.get("controller-url", "")
-        # FIXME: Quick hack to fix a k8s bug in the controller charm.
         controller_url = (
             controller_url.replace("[", "").replace(":0]", "").replace("]", "")
         )

--- a/k8s-charm/src/charm.py
+++ b/k8s-charm/src/charm.py
@@ -118,7 +118,7 @@ class JujuDashboardKubernetesCharm(CharmBase):
         config_template = env.get_template("src/config.js.j2")
         config = config_template.render(
             base_app_url="/",
-            controller_api_endpoint="/api",
+            controller_api_endpoint= ("" if self._bool(is_juju) else controller_url) + "/api",
             identity_provider_url=identity_provider_url,
             is_juju=is_juju,
             analytics_enabled=self.config.get('analytics-enabled'),
@@ -130,6 +130,7 @@ class JujuDashboardKubernetesCharm(CharmBase):
             controller_ws_api=controller_url.replace("wss", "https"),
             dashboard_root="/srv",
             port=DASHBOARD_PORT,
+            is_juju=is_juju,
         )
 
         return config, nginx_config

--- a/k8s-charm/src/charm.py
+++ b/k8s-charm/src/charm.py
@@ -23,7 +23,7 @@ class JujuDashboardKubernetesCharm(CharmBase):
 
     This is the kubernetes version of the Juju Dashboard charm. The charm creates a nodejs
     service providing the dashboard gui for a Juju controller. Relating to a controller
-    gives the dashboad the information it needs to talk to a specific local controller.
+    gives the dashboard the information it needs to talk to a specific local controller.
 
     This charm requires a `controller` endpoint, and provides a `dashboard` endpoint.
     - The controller relation allows the dashboard to connect to a Juju controller.

--- a/k8s-charm/src/charm.py
+++ b/k8s-charm/src/charm.py
@@ -130,7 +130,7 @@ class JujuDashboardKubernetesCharm(CharmBase):
             controller_ws_api=controller_url.replace("wss://", "https://"),
             dashboard_root="/srv",
             port=DASHBOARD_PORT,
-            is_juju=is_juju,
+            is_juju=self._bool(is_juju),
         )
 
         return config, nginx_config

--- a/k8s-charm/src/charm.py
+++ b/k8s-charm/src/charm.py
@@ -118,7 +118,7 @@ class JujuDashboardKubernetesCharm(CharmBase):
         config_template = env.get_template("src/config.js.j2")
         config = config_template.render(
             base_app_url="/",
-            controller_api_endpoint= ("" if self._bool(is_juju) else controller_url) + "/api",
+            controller_api_endpoint=("" if self._bool(is_juju) else controller_url) + "/api",
             identity_provider_url=identity_provider_url,
             is_juju=is_juju,
             analytics_enabled=self.config.get('analytics-enabled'),
@@ -127,7 +127,7 @@ class JujuDashboardKubernetesCharm(CharmBase):
         nginx_template = env.get_template("src/nginx.conf.j2")
         nginx_config = nginx_template.render(
             # nginx proxy_pass expects the protocol to be https
-            controller_ws_api=controller_url.replace("wss", "https"),
+            controller_ws_api=controller_url.replace("wss://", "https://"),
             dashboard_root="/srv",
             port=DASHBOARD_PORT,
             is_juju=is_juju,

--- a/k8s-charm/src/config.js.j2
+++ b/k8s-charm/src/config.js.j2
@@ -3,8 +3,6 @@ var jujuDashboardConfig = {
   controllerAPIEndpoint: "{{controller_api_endpoint}}",
   // Configurable base url to allow deploying to different paths.
   baseAppURL: "{{base_app_url}}",
-  // If true then identity will be provided by a third party provider.
-  identityProviderAvailable: {{identity_provider_url | bool | tojson}},
   // The URL of the third party identity provider.
   identityProviderURL: "{{identity_provider_url}}",
   // Is this application being rendered in Juju and not JAAS. This flag should

--- a/k8s-charm/src/nginx.conf.j2
+++ b/k8s-charm/src/nginx.conf.j2
@@ -24,6 +24,7 @@ server {
         try_files $uri =404; 
     }
 
+{% if is_juju == true or (is_juju is string and is_juju | lower == "true") %}
     location ~ /api$ {
         proxy_pass {{controller_ws_api}};
         proxy_http_version 1.1;
@@ -39,4 +40,5 @@ server {
         proxy_set_header Connection $connection_upgrade;
         proxy_set_header Host $host;
     }
+{% endif %}
 }

--- a/k8s-charm/src/nginx.conf.j2
+++ b/k8s-charm/src/nginx.conf.j2
@@ -20,8 +20,8 @@ server {
         try_files /config.js =404;
     }
 
-    location /static {
-        try_files $uri $uri/ =404; 
+    location /assets {
+        try_files $uri =404; 
     }
 
     location ~ /api$ {

--- a/k8s-charm/src/nginx.conf.j2
+++ b/k8s-charm/src/nginx.conf.j2
@@ -24,7 +24,7 @@ server {
         try_files $uri =404; 
     }
 
-{% if is_juju == true or (is_juju is string and is_juju | lower == "true") %}
+{% if is_juju %}
     location ~ /api$ {
         proxy_pass {{controller_ws_api}};
         proxy_http_version 1.1;

--- a/k8s-charm/tests/test_charm.py
+++ b/k8s-charm/tests/test_charm.py
@@ -30,14 +30,14 @@ class TestCharm(unittest.TestCase):
 
     def test_on_controller_relation_changed(self):
         self.harness.update_relation_data(self.rel_id, "controller", {
-            "is-juju": "False",
+            "is-juju": "True",
         })
         with self.container.pull('/etc/nginx/sites-available/default') as f:
             nginx_config = f.read()
         self.assertTrue("https://10.10.10.1:107070" in nginx_config)
         with self.container.pull('/srv/config.js') as f:
             config = f.read()
-        self.assertTrue("isJuju: false" in config)
+        self.assertTrue("isJuju: true" in config)
 
     def test_relation_departed(self):
         self.harness.model.unit.status = ActiveStatus()

--- a/machine-charm/lib/charms/juju_dashboard/v0/juju_dashboard.py
+++ b/machine-charm/lib/charms/juju_dashboard/v0/juju_dashboard.py
@@ -72,11 +72,7 @@ class JujuDashData(Mapping):
 
         """
         # Juju controller provides is-juju, while JAAS provides is_juju.
-        is_juju = (
-            data.get("is_juju", True)
-            if data.get("is-juju") is None
-            else data.get("is-juju")
-        )
+        is_juju = data.get("is-juju", True)
         # Juju controller provides controller-url, while JAAS provides controller_url.
         controller_url = data.get("controller_url") or data.get("controller-url", "")
         self._data = {

--- a/machine-charm/lib/charms/juju_dashboard/v0/juju_dashboard.py
+++ b/machine-charm/lib/charms/juju_dashboard/v0/juju_dashboard.py
@@ -72,7 +72,11 @@ class JujuDashData(Mapping):
 
         """
         # Juju controller provides is-juju, while JAAS provides is_juju.
-        is_juju = data.get("is_juju") or data.get("is-juju", True)
+        is_juju = (
+            data.get("is_juju", True)
+            if data.get("is-juju") is None
+            else data.get("is-juju")
+        )
         # Juju controller provides controller-url, while JAAS provides controller_url.
         controller_url = data.get("controller_url") or data.get("controller-url", "")
         self._data = {

--- a/machine-charm/lib/charms/juju_dashboard/v0/juju_dashboard.py
+++ b/machine-charm/lib/charms/juju_dashboard/v0/juju_dashboard.py
@@ -71,10 +71,22 @@ class JujuDashData(Mapping):
                 juju-controller application.
 
         """
+        # Juju controller provides is-juju, while JAAS provides is_juju.
+        is_juju = (
+            data.get("is_juju", True)
+            if data.get("is-juju") is None
+            else data.get("is-juju")
+        )
+        # Juju controller provides controller-url, while JAAS provides controller_url.
+        controller_url = (
+            data.get("controller_url", "")
+            if data.get("controller-url") is None
+            else data.get("controller-url")
+        )
         self._data = {
-            "controller_url": re.sub(r'\/api$', '', data.get("controller-url", "")),
+            "controller_url": re.sub(r'\/api$', '', controller_url),
             "identity_provider_url": data.get("identity-provider-url", ""),
-            "is_juju": data.get("is-juju", True),
+            "is_juju": is_juju,
         }
 
     def __contains__(self, key):

--- a/machine-charm/lib/charms/juju_dashboard/v0/juju_dashboard.py
+++ b/machine-charm/lib/charms/juju_dashboard/v0/juju_dashboard.py
@@ -72,17 +72,9 @@ class JujuDashData(Mapping):
 
         """
         # Juju controller provides is-juju, while JAAS provides is_juju.
-        is_juju = (
-            data.get("is_juju", True)
-            if data.get("is-juju") is None
-            else data.get("is-juju")
-        )
+        is_juju = data.get("is_juju") or data.get("is-juju", True)
         # Juju controller provides controller-url, while JAAS provides controller_url.
-        controller_url = (
-            data.get("controller_url", "")
-            if data.get("controller-url") is None
-            else data.get("controller-url")
-        )
+        controller_url = data.get("controller_url") or data.get("controller-url", "")
         self._data = {
             "controller_url": re.sub(r'\/api$', '', controller_url),
             "identity_provider_url": data.get("identity-provider-url", ""),

--- a/machine-charm/lib/charms/juju_dashboard/v0/juju_dashboard.py
+++ b/machine-charm/lib/charms/juju_dashboard/v0/juju_dashboard.py
@@ -71,14 +71,10 @@ class JujuDashData(Mapping):
                 juju-controller application.
 
         """
-        # Juju controller provides is-juju, while JAAS provides is_juju.
-        is_juju = data.get("is-juju", True)
-        # Juju controller provides controller-url, while JAAS provides controller_url.
-        controller_url = data.get("controller_url") or data.get("controller-url", "")
         self._data = {
-            "controller_url": re.sub(r'\/api$', '', controller_url),
+            "controller_url": re.sub(r'\/api$', '', data.get("controller-url", "")),
             "identity_provider_url": data.get("identity-provider-url", ""),
-            "is_juju": is_juju,
+            "is_juju": data.get("is-juju", True),
         }
 
     def __contains__(self, key):

--- a/machine-charm/src/charm.py
+++ b/machine-charm/src/charm.py
@@ -94,7 +94,7 @@ class JujuDashboardCharm(CharmBase):
         config_template = env.get_template("src/config.js.template")
         config_template.stream(
             base_app_url="/",
-            controller_api_endpoint="/api",
+            controller_api_endpoint=("" if self._bool(is_juju) else controller_url) + "/api",
             identity_provider_url=identity_provider_url,
             is_juju=is_juju,
             analytics_enabled=self.config.get('analytics-enabled')
@@ -113,7 +113,8 @@ class JujuDashboardCharm(CharmBase):
         nginx_template = nginx_template.stream(
             controller_ws_api=controller_url,
             dashboard_root=os.getcwd(),
-            dns_name=self.config.get('dns-name')
+            dns_name=self.config.get('dns-name'),
+            is_juju=is_juju
         ).dump("/etc/nginx/sites-available/default")
 
         nginx_status = os.system("sudo systemctl restart nginx")

--- a/machine-charm/src/charm.py
+++ b/machine-charm/src/charm.py
@@ -23,7 +23,7 @@ class JujuDashboardCharm(CharmBase):
 
     This is the "machine" version of the Juju Dashboard charm. The charm deploys a nodejs
     service (jass-dashboard), which provides the dashboard gui for a Juju
-    controller. Relating to a controller gives the dashboad the information it needs to
+    controller. Relating to a controller gives the dashboard the information it needs to
     talk to a specific local controller.
 
     This charm requires a `controller` endpoint, and provides a `dashboard` endpoint.

--- a/machine-charm/src/charm.py
+++ b/machine-charm/src/charm.py
@@ -114,7 +114,7 @@ class JujuDashboardCharm(CharmBase):
             controller_ws_api=controller_url,
             dashboard_root=os.getcwd(),
             dns_name=self.config.get('dns-name'),
-            is_juju=is_juju
+            is_juju=self._bool(is_juju)
         ).dump("/etc/nginx/sites-available/default")
 
         nginx_status = os.system("sudo systemctl restart nginx")

--- a/machine-charm/src/config.js.template
+++ b/machine-charm/src/config.js.template
@@ -3,8 +3,6 @@ var jujuDashboardConfig = {
   controllerAPIEndpoint: "{{controller_api_endpoint}}",
   // Configurable base url to allow deploying to different paths.
   baseAppURL: "{{base_app_url}}",
-  // If true then identity will be provided by a third party provider.
-  identityProviderAvailable: {{identity_provider_url | bool | tojson}},
   // The URL of the third party identity provider.
   identityProviderURL: "{{identity_provider_url}}",
   // Is this application being rendered in Juju and not JAAS. This flag should

--- a/machine-charm/src/nginx.conf.template
+++ b/machine-charm/src/nginx.conf.template
@@ -30,7 +30,7 @@ server {
         try_files $uri =404; 
     }
 
-{% if is_juju == true or (is_juju is string and is_juju | lower == "true") %}
+{% if is_juju %}
     location ~ /api$ {
         proxy_pass {{controller_ws_api}};
         proxy_http_version 1.1;

--- a/machine-charm/src/nginx.conf.template
+++ b/machine-charm/src/nginx.conf.template
@@ -30,6 +30,7 @@ server {
         try_files $uri =404; 
     }
 
+{% if is_juju == true or (is_juju is string and is_juju | lower == "true") %}
     location ~ /api$ {
         proxy_pass {{controller_ws_api}};
         proxy_http_version 1.1;
@@ -45,4 +46,5 @@ server {
         proxy_set_header Connection $connection_upgrade;
         proxy_set_header Host $host;
     }
+{% endif %}
 }

--- a/machine-charm/src/nginx.conf.template
+++ b/machine-charm/src/nginx.conf.template
@@ -26,8 +26,8 @@ server {
         try_files /config.js =404;
     }
 
-    location /static {
-        try_files $uri $uri/ =404; 
+    location /assets {
+        try_files $uri =404; 
     }
 
     location ~ /api$ {


### PR DESCRIPTION
## QA
### How to test dashboard k8s charm with jimm

1. Have jimm k8s charm running. One way to do that is to follow the [integration tests instructions](https://github.com/canonical/jimm-k8s-operator/blob/v3/CONTRIBUTING.md#integration-tests). At the end of my current instructions I've copy-pasted the exact commands that would create a multipass instance in which all the necessary dependencies are installed in order to run the integration tests successfully and deploy a working jimm k8s charm.
2. Build the dashboard with the changes from [this PR](https://github.com/canonical/juju-dashboard/pull/1803):
```
git clone -b before-0.13.0-release git@github.com:vladimir-cucu/juju-dashboard.git
cd juju-dashboard
DOCKER_BUILDKIT=1 docker build -t juju-dashboard .
docker image save juju-dashboard | microk8s ctr image import -
```
3. Package the charm with the changes from the current PR and deploy/refresh the dashboard k8s charm:
```
git clone -b before-0.13.0-release-changes git@github.com:vladimir-cucu/juju-dashboard-charm.git
cd juju-dashboard-charm/k8s-charm
docker image inspect juju-dashboard | grep "Id"
# To deploy the dashboard
juju deploy --resource dashboard-image=[docker-image-id] ./juju-dashboard*.charm dashboard
# To refresh the dashboard
juju refresh --resource dashboard-image=[docker-image-id] --path ./juju-dashboard*.charm dashboard
```
4. Relate the dashboard with jimm (if not done already) and change the jimm config accordingly:
```
juju integrate dashboard juju-jimm-k8s
juju config juju-jimm-k8s cors-allowed-origins=http://[dashboard-address]:8080
juju config juju-jimm-k8s juju-dashboard-location=http://[dashboard-address]:8080/models
```
5. Open the dashboard from the browser at `http://[dashboard-address]:8080` and hopefully everything works :).

### Further notes
**Steps for running the integration tests in multipass:**
```
multipass launch --cpus 2 --disk 40G --memory 8G --name jimm noble
cat ~/.ssh/id_ed25519.pub | multipass exec jimm -- tee -a .ssh/authorized_keys
ssh -A ubuntu@[jimm-multipass-ip]
sudo snap install microk8s --channel=1.28-strict/stable
sudo usermod -a -G snap_microk8s ubuntu
mkdir /home/ubuntu/.kube
sudo chown -R ubuntu ~/.kube
newgrp snap_microk8s
sudo microk8s enable hostpath-storage dns ingress host-access registry
sudo microk8s disable rbac
sudo microk8s enable metallb:10.64.140.43-10.64.140.100
sudo snap install juju --channel=3.5/stable
mkdir -p ~/.local/share
juju bootstrap microk8s
sudo snap install kubectl --channel=1.29/stable --classic
microk8s config > ~/.kube/config
sudo snap install charmcraft --channel=3.x/stable --classic
lxd init --auto
sudo apt install python3-virtualenv
sudo snap install node --classic
sudo npx playwright install-deps
git clone git@github.com:canonical/jimm-k8s-operator.git
cd jimm-k8s-operator/
virtualenv -p python3 venv
source venv/bin/activate
pip install tox
tox -e integration -- --keep-models
```

**For dashboard machine charm**: `./machine-charm/src/dist` should be modified with the built version of the dashboard that has the changes from [this PR](https://github.com/canonical/juju-dashboard/pull/1803).

## Details

- https://warthogs.atlassian.net/browse/WD-13385