### PR TITLE
feat: support fetching the dashboard by version

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Once you login following the instructions in the output of `juju dashboard` you 
 
 This script pulls that latest Github release of the dashboard and extracts it to the appropriate folder in `machine-charm`:
 
+Note: you can optionally pass a dashboard release tag to the script e.g. `./scripts/update-machine-charm-dashboard.sh 1.2.3`
+
 ```sh
 ./scripts/update-machine-charm-dashboard.sh
 ```

--- a/scripts/update-machine-charm-dashboard.sh
+++ b/scripts/update-machine-charm-dashboard.sh
@@ -1,14 +1,15 @@
 #! /bin/bash
 
+DASHBOARD_VERSION=${1:-latest}
 dist_path=./machine-charm/src/dist
 
 # delete existing version
 rm -rf $dist_path/*
 
-echo "Downloading the latest release..."
+echo "Downloading the $DASHBOARD_VERSION release..."
 rm -f *.tar.bz2
 
-wget -qO- https://api.github.com/repos/canonical/juju-dashboard/releases/latest \
+wget -qO- https://api.github.com/repos/canonical/juju-dashboard/releases/$( if [[ $DASHBOARD_VERSION != "latest" ]]; then echo "tags/"; fi)$DASHBOARD_VERSION \
 | grep tar.bz2 \
 | cut -d : -f 2,3 \
 | tr -d \" \


### PR DESCRIPTION
## Changes

Support fetching the Juju Dashboard by a release tag.

## QA

- Run `./scripts/update-machine-charm-dashboard.sh v0.14.0` and it should get the 0.14.0 release.
- Run `./scripts/update-machine-charm-dashboard.sh` and it should get the latest release.