### PR TITLE
chore(deps): require newer versions of setuptools

### DIFF
--- a/k8s-charm/charmcraft.yaml
+++ b/k8s-charm/charmcraft.yaml
@@ -15,4 +15,4 @@ bases:
 
 parts:
   charm:
-    charm-python-packages: [setuptools]
+    charm-python-packages: [setuptools>80.0]

--- a/machine-charm/charmcraft.yaml
+++ b/machine-charm/charmcraft.yaml
@@ -15,4 +15,4 @@ bases:
 
 parts:
   charm:
-    charm-python-packages: [setuptools]
+    charm-python-packages: [setuptools>80.0]


### PR DESCRIPTION
Require a recent version of setuptools to prevent installation of older, insecure versions.