### PR TITLE
chore: add archive note to juju-dashboard-charm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Juju Dashboard Charm
 
+> [!NOTE]
+> This repository has been archived as the charms here have now been moved into the [Juju Dashboard](https://github.com/canonical/juju-dashboard/tree/main/charms). Any new updates to these charms will be made there.
+
 This repository contains charms that deploy the dashboard for [Juju](https://juju.is) and [JAAS](https://jaas.ai) into Machine and Kubernetes environments.
 
 [![Charm for Juju Dashboard


### PR DESCRIPTION
Adding a note before archiving this repository as the source code here has been merged into the [juju-dashboard](https://github.com/canonical/juju-dashboard/tree/main/charms) repository. Refer [this](https://docs.google.com/document/d/19ZFO_YJUdwtlb6daXqdxr5QkwlqZAooTI0dYn1jWhWo/edit?tab=t.0#heading=h.jqdczyl3bpp9) for further information.